### PR TITLE
[ISSUE-6][Bug Fix] 修复单个单词加句号无法分句的问题

### DIFF
--- a/indextts/utils/front.py
+++ b/indextts/utils/front.py
@@ -372,7 +372,7 @@ class TextTokenizer:
                     current_segment, ["-"], max_text_tokens_per_segment=max_text_tokens_per_segment, quick_streaming_tokens = quick_streaming_tokens
                 )
             elif current_segment_tokens_len <= max_text_tokens_per_segment:
-                if token in split_tokens and current_segment_tokens_len > 2:
+                if token in split_tokens and current_segment_tokens_len >= 2:
                     if i < len(tokenized_str) - 1:
                         if tokenized_str[i + 1] in ["'", "▁'"]:
                             # 后续token是'，则不切分
@@ -429,6 +429,7 @@ class TextTokenizer:
         # "▁!", # unk
         "▁?",
         "▁...", # ellipsis
+        "…",
     ]
     def split_segments(self, tokenized: List[str], max_text_tokens_per_segment=120, quick_streaming_tokens = 0) -> List[List[str]]:
         return TextTokenizer.split_segments_by_token(


### PR DESCRIPTION
## 问题描述
当文本只有一个单词加句号（如 "Hello."）时，原有逻辑要求至少 3 个 token 才会分句，导致单词句子无法被正确识别。

## 解决方案
- 将分句条件从 `current_segment_tokens_len > 2` 改为 `>= 2`
- 允许 2 个 token（单词 + 句号）就可以进行分句
- 添加省略号(…)到分句标记列表

## 影响场景
- 简短对话："Yes.", "No.", "OK."
- 感叹句："Wow!", "Great!"
- 短标题："Introduction.", "Conclusion."

## 测试
- [ ] 测试单词句子能够正确分句
- [ ] 验证 SRT 字幕时间戳更准确

## 相关 Issue
迁移自 indextts1/dev-reorganized-commits 分支的改进