### PR TITLE
[ISSUE-4][Bug Fix] 修复 Position Embedding 索引越界问题

### DIFF
--- a/indextts/gpt/model_v2.py
+++ b/indextts/gpt/model_v2.py
@@ -252,6 +252,10 @@ class LearnedPositionEmbeddings(nn.Module):
         return self.emb(torch.arange(0, sl, device=x.device))
 
     def get_fixed_embedding(self, ind, dev):
+        # 添加边界检查，避免索引越界
+        if ind >= self.emb.num_embeddings:
+            print(f"[WARNING] Position index {ind} exceeds embedding size {self.emb.num_embeddings}, using last position")
+            ind = self.emb.num_embeddings - 1
         return self.emb(torch.tensor([ind], device=dev)).unsqueeze(0)
 
 


### PR DESCRIPTION
## 问题描述
在 `LearnedPositionEmbeddings.get_fixed_embedding()` 中缺少边界检查，当索引超过 embedding 大小时会导致程序崩溃。

## 解决方案
- 在 `get_fixed_embedding()` 方法中添加边界检查
- 当索引超过 embedding 大小时，使用最后一个位置的 embedding
- 打印警告信息以便调试

## 修改内容
```python
def get_fixed_embedding(self, ind, dev):
    # 添加边界检查，避免索引越界
    if ind >= self.emb.num_embeddings:
        print(f"[WARNING] Position index {ind} exceeds embedding size {self.emb.num_embeddings}, using last position")
        ind = self.emb.num_embeddings - 1
    return self.emb(torch.tensor([ind], device=dev)).unsqueeze(0)
```

## 效果
- ✅ 避免程序因索引越界而崩溃
- ✅ 提供清晰的警告信息
- ✅ 确保在边界情况下仍能继续运行

## 测试
- [ ] 测试超长句子不会导致程序崩溃
- [ ] 验证边界检查警告能正常打印

## 相关 Issue
迁移自 indextts1/dev-reorganized-commits 分支的改进