### PR TITLE
chore: add hf_cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ desktop.ini
 /checkpoints/*
 !/checkpoints/*.yaml
 /outputs/
+examples/checkpoints/hf_cache/


### PR DESCRIPTION
## Summary
- Add `examples/checkpoints/hf_cache/` to .gitignore to exclude HuggingFace model cache files

🤖 Generated with [Claude Code](https://claude.com/claude-code)