### PR TITLE
[ISSUE-15][Bug Fix] 修复逗号意外触发分句导致字幕过度分割

### DIFF
--- a/indextts/utils/front.py
+++ b/indextts/utils/front.py
@@ -361,17 +361,9 @@ class TextTokenizer:
             token = tokenized_str[i]
             current_segment.append(token)
             current_segment_tokens_len += 1
-            if not  ("," in split_tokens or "▁," in split_tokens ) and ("," in current_segment or "▁," in current_segment): 
-                # 如果当前tokens中有,，则按,分割
-                sub_segments = TextTokenizer.split_segments_by_token(
-                    current_segment, [",", "▁,"], max_text_tokens_per_segment=max_text_tokens_per_segment, quick_streaming_tokens = quick_streaming_tokens
-                )
-            elif "-" not in split_tokens and "-" in current_segment:
-                # 没有,，则按-分割
-                sub_segments = TextTokenizer.split_segments_by_token(
-                    current_segment, ["-"], max_text_tokens_per_segment=max_text_tokens_per_segment, quick_streaming_tokens = quick_streaming_tokens
-                )
-            elif current_segment_tokens_len <= max_text_tokens_per_segment:
+
+            # ✅ 正确：先检查主要标点
+            if current_segment_tokens_len <= max_text_tokens_per_segment:
                 if token in split_tokens and current_segment_tokens_len >= 2:
                     if i < len(tokenized_str) - 1:
                         if tokenized_str[i + 1] in ["'", "▁'"]:
@@ -382,7 +374,18 @@ class TextTokenizer:
                     current_segment = []
                     current_segment_tokens_len = 0
                 continue
-            # 如果当前tokens的长度超过最大限制
+
+            # ✅ 正确：只有超长时才用逗号兜底
+            if not ("," in split_tokens or "▁," in split_tokens) and ("," in current_segment or "▁," in current_segment):
+                # 如果当前tokens中有,，则按,分割
+                sub_segments = TextTokenizer.split_segments_by_token(
+                    current_segment, [",", "▁,"], max_text_tokens_per_segment=max_text_tokens_per_segment, quick_streaming_tokens = quick_streaming_tokens
+                )
+            elif "-" not in split_tokens and "-" in current_segment:
+                # 没有,，则按-分割
+                sub_segments = TextTokenizer.split_segments_by_token(
+                    current_segment, ["-"], max_text_tokens_per_segment=max_text_tokens_per_segment, quick_streaming_tokens = quick_streaming_tokens
+                )
             else:
                 # 按照长度分割
                 sub_segments = []


### PR DESCRIPTION
close #15 

## Summary

修复了逗号（`,`）意外触发句子分割的问题，导致字幕过度细分和语音节奏不自然。

## 问题描述

当前版本中，逗号会无条件触发句子分割，导致：
- 字幕（SRT）过度细分，一句话被拆成多条字幕
- 语音节奏不自然，出现不必要的停顿
- 与预期行为不符：用户期望只有句号、问号、感叹号等句末标点才分句

**示例：**
- 输入：`第一句，第二句，第三句。`
- 修复前：生成 3 个 segment（按逗号分句）
- 修复后：生成 1 个 segment（只按句号分句）

## 修改内容

实现方案 1（issue #15 推荐方案）：恢复原始逻辑

在 `indextts/utils/front.py` 的 `split_segments_by_token` 方法中：
- ✅ 将主要标点符号（句号、问号、感叹号）的检查逻辑移到前面优先执行
- ✅ 将逗号分句逻辑移到后面，只在句子超过最大长度限制时作为兜底机制
- ✅ 保持了超长句子的逗号和连字符兜底机制

## Test plan

- [ ] 测试基本分句：`第一句，第二句，第三句。` 应该生成 1 个 segment
- [ ] 测试句号分句：`第一句。第二句。第三句。` 应该生成 3 个 segment
- [ ] 测试超长句子：逗号作为兜底机制应该正常工作
- [ ] 运行现有测试用例确保无回归

## 相关 Issue

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)