### PR TITLE
[ISSUE-19] 新增 FastAPI HTTP 服务，支持工作流调用并返回 wav+srt 路径

### DIFF
--- a/http_service.py
+++ b/http_service.py
@@ -1,0 +1,154 @@
+"""IndexTTS2 HTTP service.
+
+Tutorial:
+    uv sync --extra http_service
+    uv run python http_service.py
+
+Endpoint:
+    POST /synthesize  body: {"text": "..."}  returns {"wav_path": "...", "srt_path": "..."}
+
+Paths in the response are relative to OUTPUT_ROOT and meant to be served via filehub.
+"""
+
+import argparse
+import asyncio
+import datetime
+import logging
+import os
+import sys
+import uuid
+import warnings
+
+warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(current_dir)
+sys.path.append(os.path.join(current_dir, "indextts"))
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import uvicorn
+
+from indextts.infer_v2 import IndexTTS2
+
+OUTPUT_ROOT = "/home/fanrui/agbox-paseo-shared/read-only/indextts2_service_voices"
+DEFAULT_SPEAKER_AUDIO = (
+    "/home/fanrui/code/tts-service/materials/"
+    "en-US-AndrewMultilingual-Relieved-Audio.wav"
+)
+DEFAULT_MODEL_DIR = os.path.join(current_dir, "checkpoints")
+DEFAULT_CFG_PATH = os.path.join(DEFAULT_MODEL_DIR, "config.yaml")
+
+logger = logging.getLogger("indextts2.http")
+
+
+class SynthesizeRequest(BaseModel):
+    text: str
+
+
+class SynthesizeResponse(BaseModel):
+    wav_path: str
+    srt_path: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="IndexTTS2 HTTP Service")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=37861)
+    parser.add_argument("--model_dir", default=DEFAULT_MODEL_DIR)
+    parser.add_argument("--fp16", action="store_true", default=True)
+    parser.add_argument("--deepspeed", action="store_true", default=False)
+    parser.add_argument("--cuda_kernel", action="store_true", default=False)
+    return parser.parse_args()
+
+
+def validate_model_dir(model_dir: str) -> None:
+    if not os.path.isdir(model_dir):
+        raise SystemExit(f"Model directory not found: {model_dir}")
+    required = ["bpe.model", "gpt.pth", "config.yaml", "s2mel.pth", "wav2vec2bert_stats.pt"]
+    missing = [f for f in required if not os.path.isfile(os.path.join(model_dir, f))]
+    if missing:
+        raise SystemExit(f"Missing model files in {model_dir}: {missing}")
+
+
+def validate_speaker_audio() -> None:
+    if not os.path.isfile(DEFAULT_SPEAKER_AUDIO):
+        raise SystemExit(f"Default speaker audio not found: {DEFAULT_SPEAKER_AUDIO}")
+
+
+def build_app(tts: IndexTTS2) -> FastAPI:
+    app = FastAPI(title="IndexTTS2 HTTP Service")
+    # Process-wide lock: GPU inference must run one at a time.
+    inference_lock = asyncio.Lock()
+
+    @app.post("/synthesize", response_model=SynthesizeResponse)
+    async def synthesize(req: SynthesizeRequest) -> SynthesizeResponse:
+        text = req.text.strip()
+        if not text:
+            raise HTTPException(status_code=400, detail="text cannot be empty")
+
+        task_id = uuid.uuid4().hex
+        date_dir = datetime.datetime.utcnow().strftime("%Y%m%d")
+        rel_dir = os.path.join(date_dir, task_id)
+        abs_dir = os.path.join(OUTPUT_ROOT, rel_dir)
+        os.makedirs(abs_dir, exist_ok=True)
+
+        wav_rel = os.path.join(rel_dir, "0.wav")
+        srt_rel = os.path.join(rel_dir, "0.srt")
+        wav_abs = os.path.join(OUTPUT_ROOT, wav_rel)
+        srt_abs = os.path.join(OUTPUT_ROOT, srt_rel)
+
+        logger.info("synthesize task_id=%s text_len=%d", task_id, len(text))
+
+        # Serialize all GPU inference; offload to a thread so the event loop is free.
+        async with inference_lock:
+            try:
+                await asyncio.to_thread(
+                    tts.infer,
+                    spk_audio_prompt=DEFAULT_SPEAKER_AUDIO,
+                    text=text,
+                    output_path=wav_abs,
+                    stream_return=False,
+                )
+            except Exception as e:
+                logger.exception("synthesize failed task_id=%s", task_id)
+                raise HTTPException(status_code=500, detail=f"synthesis failed: {e}") from e
+
+        if not os.path.isfile(wav_abs):
+            raise HTTPException(status_code=500, detail="wav file was not generated")
+        if not os.path.isfile(srt_abs):
+            raise HTTPException(status_code=500, detail="srt file was not generated")
+
+        return SynthesizeResponse(wav_path=wav_rel, srt_path=srt_rel)
+
+    return app
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    args = parse_args()
+    validate_model_dir(args.model_dir)
+    validate_speaker_audio()
+    os.makedirs(OUTPUT_ROOT, exist_ok=True)
+
+    logger.info("loading IndexTTS2 model from %s", args.model_dir)
+    tts = IndexTTS2(
+        model_dir=args.model_dir,
+        cfg_path=os.path.join(args.model_dir, "config.yaml"),
+        use_fp16=args.fp16,
+        use_deepspeed=args.deepspeed,
+        use_cuda_kernel=args.cuda_kernel,
+    )
+    logger.info("model loaded")
+
+    app = build_app(tts)
+    uvicorn.run(app, host=args.host, port=args.port, workers=1, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,11 @@ webui = [
 deepspeed = [
   "deepspeed==0.17.1",
 ]
+# To install the HTTP service support, use `uv sync --extra http_service` (or `--all-extras`).
+http_service = [
+  "fastapi>=0.115.0",
+  "uvicorn>=0.30.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/index-tts/index-tts"

--- a/requirements/http_service/user_requirements.md
+++ b/requirements/http_service/user_requirements.md
@@ -1,0 +1,84 @@
+# IndexTTS2 HTTP Service 需求
+
+## 背景
+
+需要在工作流（n8n 等）中调用 IndexTTS2 做文本转语音并拿到细粒度 SRT 字幕。
+
+- 工作流平台只支持 HTTP，gRPC 不可用。
+- 业界 TTS 部署没有返回细粒度 SRT 的现成方案；细粒度 SRT 是本仓自定义扩展（`indextts/infer_v2.py:403` `generate_srt`）。
+- 已有的 `tts-service`（gRPC）服务不在改造范围内，继续保留给后端轮询使用。
+- 调用方仅限作者自己的工作流，请求量低，不开放给外部。
+
+## 服务形态
+
+在本仓库（`/home/fanrui/code/indextts2`）内新增一个 FastAPI 应用，与 IndexTTS2 同进程加载模型，直接调用 `from indextts.infer_v2 import IndexTTS2`，不跨进程。
+
+- 同步 HTTP 接口：请求阻塞直到合成完成再返回。
+- 不引入数据库、队列、回调、批量、鉴权。
+- 不引入对 `tts-service` 的依赖。
+
+## 接口
+
+### POST /synthesize
+
+请求体：
+
+```json
+{
+  "text": "待合成的文本"
+}
+```
+
+响应体：
+
+```json
+{
+  "wav_path": "20260425/<task_id>/0.wav",
+  "srt_path": "20260425/<task_id>/0.srt"
+}
+```
+
+- 请求只接受 `text` 一个字段；其他参数（speaker audio、model_dir、cfg_path 等）在服务代码里硬编码，第一版不暴露。
+- 响应只返回两个相对路径，不返回任何其他字段，不返回文件字节。
+- 路径相对于配置的输出根目录，由 filehub 托管对外读取。
+
+## 硬编码参数（v1）
+
+- `default_speaker_audio`: `/home/fanrui/code/tts-service/materials/en-US-AndrewMultilingual-Relieved-Audio.wav`
+- `model_dir`、`cfg_path`、`use_fp16`、`use_deepspeed`、`use_cuda_kernel` 复用本仓现有默认/已有约定，不通过 HTTP 暴露。
+
+## 输出目录约定
+
+输出根目录：`/home/fanrui/agbox-paseo-shared/read-only/indextts2_service_voices`
+
+目录结构（参考 comfyui_service `executor.go:196`）：
+
+```
+<output_root>/
+  <YYYYMMDD>/
+    <task_id>/
+      0.wav
+      0.srt
+```
+
+- 日期取 UTC 当天，格式 `YYYYMMDD`。
+- `task_id` 用 uuid4，保证并发不撞目录。
+- `0.wav` 与 `0.srt` 同名同目录，由 IndexTTS2 推理一次产出。
+- 接口返回 `wav_path` / `srt_path` 是相对 `<output_root>` 的相对路径，不带前导 `/`。
+
+## 行为约束
+
+- 模型在服务启动时加载一次，常驻；不做按请求加载。
+- 一次请求只生成一组 wav+srt，不支持批量。
+- 合成完成前 HTTP 连接保持打开；不返回任务 ID 让客户端轮询。
+- 失败返回非 2xx 状态码与错误信息字符串；不做重试。
+- 不清理输出目录；保留供 filehub 服务读取，由人工或外部脚本管理生命周期。
+- 单 GPU 串行：handler 内用进程级锁（`asyncio.Lock`）保护推理调用，同一时刻只允许一个请求进入 `engine.infer`，其余请求在锁上排队等待。不限制队列长度。
+
+## 不做的事
+
+- 不做异步任务、任务队列、callback。
+- 不做鉴权、限流、并发控制。
+- 不做多 voice / 多 speed / 多 speaker 切换；这些参数 v1 不开放。
+- 不做服务化部署脚本（systemd unit）；第一版本人工 `uv run` 启动即可。
+- 不做与 `tts-service` 的兼容、迁移、调用关系。

--- a/uv.lock
+++ b/uv.lock
@@ -1202,6 +1202,10 @@ dependencies = [
 deepspeed = [
     { name = "deepspeed" },
 ]
+http-service = [
+    { name = "fastapi" },
+    { name = "uvicorn" },
+]
 webui = [
     { name = "gradio" },
 ]
@@ -1214,6 +1218,7 @@ requires-dist = [
     { name = "deepspeed", marker = "extra == 'deepspeed'", specifier = "==0.17.1" },
     { name = "descript-audiotools", specifier = "==0.7.2" },
     { name = "einops", specifier = ">=0.8.1" },
+    { name = "fastapi", marker = "extra == 'http-service'", specifier = ">=0.115.0" },
     { name = "ffmpeg-python", specifier = "==0.2.0" },
     { name = "g2p-en", specifier = "==2.1.0" },
     { name = "gradio", marker = "extra == 'webui'", specifier = "==5.45.0" },
@@ -1240,10 +1245,11 @@ requires-dist = [
     { name = "torchaudio", marker = "sys_platform == 'linux' or sys_platform == 'win32'", specifier = "==2.8.*", index = "https://download.pytorch.org/whl/cu128" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformers", specifier = "==4.52.1" },
+    { name = "uvicorn", marker = "extra == 'http-service'", specifier = ">=0.30.0" },
     { name = "wetext", marker = "sys_platform != 'linux'", specifier = ">=0.0.9" },
     { name = "wetextprocessing", marker = "sys_platform == 'linux'" },
 ]
-provides-extras = ["webui", "deepspeed"]
+provides-extras = ["webui", "deepspeed", "http-service"]
 
 [[package]]
 name = "inflect"
@@ -3540,16 +3546,16 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp310-cp310-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp311-cp311-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp312-cp312-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313t-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0c96999d15cf1f13dd7c913e0b21a9a355538e6cfc10861a17158320292f5954", upload-time = "2025-10-01T23:47:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp310-cp310-win_amd64.whl", hash = "sha256:43938e9a174c90e5eb9e906532b2f1e21532bbfa5a61b65193b4f54714d34f9e", upload-time = "2025-10-01T23:47:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:039b9dcdd6bdbaa10a8a5cd6be22c4cb3e3589a341e5f904cbb571ca28f55bed", upload-time = "2025-10-01T23:49:06Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:34c55443aafd31046a7963b63d30bc3b628ee4a704f826796c865fdfd05bb596", upload-time = "2025-10-01T23:49:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4354fc05bb79b208d6995a04ca1ceef6a9547b1c4334435574353d381c55087c", upload-time = "2025-10-01T23:51:02Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:0ad925202387f4e7314302a1b4f8860fa824357f9b1466d7992bf276370ebcff", upload-time = "2025-10-01T23:51:26Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3a852369a38dec343d45ecd0bc3660f79b88a23e0c878d18707f7c13bf49538f", upload-time = "2025-10-01T23:52:56Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:9e20646802b7fc295c1f8b45fefcfc9fb2e4ec9cbe8593443cd2b9cc307c8405", upload-time = "2025-10-01T23:53:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:4295a22d69408e93d25f51e8d5d579345b6b802383e9414b0f3853ed433d53ae", upload-time = "2025-10-01T23:54:56Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:970b4f4661fa7b44f6a7e6df65de7fc4a6fff2af610dc415c1d695ca5f1f37d2", upload-time = "2025-10-01T23:55:23Z" },
 ]
 
 [[package]]
@@ -3612,16 +3618,16 @@ dependencies = [
     { name = "torch", version = "2.8.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a0161e95285a0b716de210fee0392151d601e7da3cc86595008d826abff48a8c" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp310-cp310-win_amd64.whl", hash = "sha256:5d7a9d913e2744573ed3b7ec2f781ed39833c81c9c41859973ec10ac174c2366" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f4409df567d0723a7a3a89d32c7552a17e0ff6f137ea26a0d268c665259b2995" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:7a1eb6154e05b8056b34c7a41495e09d57f79eb0180eb4e7f3bb2a61845ca8ea" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:145b8a0c21cfcaa1705c67173c5d439087e0e120d5da9bc344746f937901d243" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:cce3a60cd9a97f7360c8f95504ac349311fb7d6b9b826135936764f4de5f782d" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:410bb8ea46225efe658e5d27a3802c181a2255913003621a5d25a51aca8018d9" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:3146bbd48992d215f6bb1aef9626d734c3180b377791ded2a4d4d2c0e63c0cc2" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:04b410f93337fc6c16576d0c88e2a31091aef9d1fd212ebb8cd26899dba175e0" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:1054e0a7613cac54ed9b3784a5fcbe023748a70004d9cca74c5f9ae00a1fdfd1" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a0161e95285a0b716de210fee0392151d601e7da3cc86595008d826abff48a8c", upload-time = "2025-08-05T20:12:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp310-cp310-win_amd64.whl", hash = "sha256:5d7a9d913e2744573ed3b7ec2f781ed39833c81c9c41859973ec10ac174c2366", upload-time = "2025-08-05T20:12:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f4409df567d0723a7a3a89d32c7552a17e0ff6f137ea26a0d268c665259b2995", upload-time = "2025-08-05T20:12:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:7a1eb6154e05b8056b34c7a41495e09d57f79eb0180eb4e7f3bb2a61845ca8ea", upload-time = "2025-08-05T20:12:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:145b8a0c21cfcaa1705c67173c5d439087e0e120d5da9bc344746f937901d243", upload-time = "2025-08-05T20:12:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:cce3a60cd9a97f7360c8f95504ac349311fb7d6b9b826135936764f4de5f782d", upload-time = "2025-08-05T20:12:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:410bb8ea46225efe658e5d27a3802c181a2255913003621a5d25a51aca8018d9", upload-time = "2025-08-05T20:12:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:3146bbd48992d215f6bb1aef9626d734c3180b377791ded2a4d4d2c0e63c0cc2", upload-time = "2025-08-05T20:12:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:04b410f93337fc6c16576d0c88e2a31091aef9d1fd212ebb8cd26899dba175e0", upload-time = "2025-08-05T20:12:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:1054e0a7613cac54ed9b3784a5fcbe023748a70004d9cca74c5f9ae00a1fdfd1", upload-time = "2025-08-05T20:12:07Z" },
 ]
 
 [[package]]
@@ -3846,7 +3852,7 @@ name = "wetext"
 version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "kaldifst" },
+    { name = "kaldifst", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/742a6de1b6cd3215d5610ae0e4580f761c5dbf2e9e246afe76ed64c3f622/wetext-0.1.0.tar.gz", hash = "sha256:0f9645bc4b6c90119d54dd9f752db40497630a05af80e627f114204cc78f3ad5", size = 1457764, upload-time = "2025-09-08T14:23:47.85Z" }
 wheels = [


### PR DESCRIPTION
close #19

## Summary

新增一个最小 FastAPI HTTP 服务，让 n8n 等工作流平台能调用 IndexTTS2 做文本转语音并拿到细粒度 SRT 字幕。服务与 IndexTTS2 同进程加载模型，单接口 `POST /synthesize`，请求体只接受 `text`，响应只返回 wav 和 srt 的相对路径，文件由 filehub 托管对外读取。

## Commits

1. `[ISSUE-19] 新增 HTTP 服务需求文档` — `requirements/http_service/user_requirements.md`
2. `[ISSUE-19] 新增 http_service 可选依赖` — `pyproject.toml` 加 `http_service` extra（fastapi + uvicorn）+ `uv.lock`
3. `[ISSUE-19] 实现 FastAPI HTTP 服务` — `http_service.py`

## 关键设计点

- **同步阻塞接口**：v1 不做异步任务/callback，TTS 一两秒出结果，同步返回相对路径最简单
- **相对路径返回**：参考 comfyui_service `OutputPaths`，路径相对 `OUTPUT_ROOT`，filehub 把这个目录配成 root 即可直接拼出 URL
- **目录结构**：`<root>/<YYYYMMDD>/<task_id>/0.{wav,srt}`，`task_id` 用 uuid4，并发不撞目录
- **GPU 串行**：handler 内 `asyncio.Lock` 保护推理调用，避免显存峰值翻倍 OOM；推理通过 `asyncio.to_thread` 卸载到工作线程，event loop 不阻塞
- **硬编码参数**：speaker audio / model_dir 等不通过 HTTP 暴露，v1 写在代码里

## 启动方式

```bash
uv sync --extra http_service
uv run python http_service.py
```

默认监听 `0.0.0.0:37861`。

## Test plan

- [x] 单元/Mock 冒烟：happy path、空文本 400、engine 抛异常 → 500、缺 wav/srt → 500（验证完成）
- [x] 端到端真实模型：`POST /synthesize {"text":"Hello world..."}` 返 200，2.9s 出结果，wav 是 22050Hz PCM 单声道，srt 含细粒度时间轴（验证完成）
- [x] 并发串行验证：两请求并发，T1=0.92s、T2=1.82s（≈2× T1），锁生效（验证完成）
- [x] 改端口默认值后重启验证：监听 37861 OK（验证完成）

## 不做的事（v1）

- 异步任务 / callback / 批量
- 鉴权 / 限流 / 队列长度上限
- voice / speed / speaker 切换
- systemd 部署脚本
