### PR TITLE
[ISSUE-21] 暂时禁用句号缩写改写规则，修复英文句末误删

### DIFF
--- a/indextts/infer_v2.py
+++ b/indextts/infer_v2.py
@@ -107,20 +107,33 @@ def remove_tts_punctuation(text):
     # Handle dots specially - only remove if not at sentence end
     import re
 
-    # First, check if the text ends with a typical sentence ending
-    has_sentence_ending = bool(re.search(r'[.!?。！？]\s*$', text))
-
-    # Remove dots in abbreviations
-    # 1. Dot between letters (e.g., "J.K." -> "JK")
-    text = re.sub(r'(?<=[A-Za-z])\.(?=[A-Za-z])', '', text)
-
-    # 2. Dot after letter followed by space and uppercase (e.g., "Dr. Smith" -> "Dr Smith")
-    text = re.sub(r'(?<=[A-Za-z])\.(?=\s+[A-Z])', '', text)
-
-    # 3. Dot at the end after uppercase letters (abbreviations like "U.S.A.")
-    # Only if it doesn't look like a sentence ending
-    if not has_sentence_ending or not re.search(r'[a-z]\.\s*$', text):
-        text = re.sub(r'(?<=[A-Z])\.(?=\s*$)', '', text)
+    # NOTE: dot-handling rules below are temporarily disabled.
+    # Reason: rule 2 (`[A-Za-z]. + space + [A-Z]`) was meant to handle "Dr. Smith"
+    # style abbreviations, but it also matches normal sentence boundaries like
+    # "coffee. I drink ...", silently deleting the real period. Because the v2
+    # pipeline runs this filter on the FULL text BEFORE segmenting (unlike v1
+    # which segmented first and filtered per segment), the dropped period causes
+    # the tokenizer to merge two real sentences into one segment, leading to
+    # missing pauses in the audio and misaligned SRT subtitles.
+    # Our current scenario does not contain personal-name abbreviations, so we
+    # disable all dot rewriting and let every period reach the tokenizer as a
+    # sentence boundary. May restore (with a stricter rule, e.g. an explicit
+    # abbreviation whitelist) once the abbreviation case becomes relevant.
+    #
+    # # First, check if the text ends with a typical sentence ending
+    # has_sentence_ending = bool(re.search(r'[.!?。！？]\s*$', text))
+    #
+    # # Remove dots in abbreviations
+    # # 1. Dot between letters (e.g., "J.K." -> "JK")
+    # text = re.sub(r'(?<=[A-Za-z])\.(?=[A-Za-z])', '', text)
+    #
+    # # 2. Dot after letter followed by space and uppercase (e.g., "Dr. Smith" -> "Dr Smith")
+    # text = re.sub(r'(?<=[A-Za-z])\.(?=\s+[A-Z])', '', text)
+    #
+    # # 3. Dot at the end after uppercase letters (abbreviations like "U.S.A.")
+    # # Only if it doesn't look like a sentence ending
+    # if not has_sentence_ending or not re.search(r'[a-z]\.\s*$', text):
+    #     text = re.sub(r'(?<=[A-Z])\.(?=\s*$)', '', text)
 
     # Remove other punctuation marks
     for char, replacement in TTS_PUNCTUATION_TO_REMOVE.items():


### PR DESCRIPTION
close #21

## 改动

注释掉 `indextts/infer_v2.py::remove_tts_punctuation` 中处理 `.` 的三条 `re.sub` 规则，保留杂项符号清理逻辑。

## 根因

规则 2 `(?<=[A-Za-z])\.(?=\s+[A-Z])` 本意处理 `Dr. Smith` 这类称谓缩写，但 lookbehind 为 `[A-Za-z]`，把"小写字母 + 句号 + 空格 + 大写"这种**正常英文句末边界**也命中。v2 在分段前对全文执行该过滤，句号被误删后 tokenizer 少切一段，造成音频合并 + SRT 字幕错位。详细分析见 #21。

## 影响

| 场景 | 影响 |
|------|------|
| 正常英文句子 | ✅ 分段恢复正确，停顿与字幕对齐 |
| 中文文本 | ✅ 无影响 |
| `Dr.` / `Mr.` / `U.S.A.` 等缩写 | ⚠️ 缩写后会出现句末停顿，当前业务无此场景 |

后续如恢复缩写处理，应改为显式白名单，避免再次误删正常句末。

## 验证

输入 `coffee. coffee. coffee. I drink coffee every morning.`，对比 HTTP 服务输出：

- 修复前：3 段音频（最后的 `coffee` 与 `I drink ...` 一口气念）；SRT 因 `_extract_original_sentences` 静默重分配，把多出来的一句塞到首段，呈现"前两个 coffee 合并"的假象，与真实音频边界错位。
- 修复后：4 段音频，三个 `coffee.` 各自独立，`I drink coffee every morning.` 单独成段；SRT 4 条字幕逐句对齐。多次重跑结果稳定一致。
