### PR TITLE
[ISSUE-23] HTTP 服务 interval_silence=0，对齐 v1 静音/字幕语义

### DIFF
--- a/http_service.py
+++ b/http_service.py
@@ -110,6 +110,7 @@ def build_app(tts: IndexTTS2) -> FastAPI:
                     text=text,
                     output_path=wav_abs,
                     stream_return=False,
+                    interval_silence=0,
                 )
             except Exception as e:
                 logger.exception("synthesize failed task_id=%s", task_id)


### PR DESCRIPTION
close #23

## 改动

`http_service.py` 中调用 `tts.infer` 时新增 `interval_silence=0`。

## 效果

- 段间不再插入 200ms 静音，音频紧贴拼接（与 v1 一致）。
- SRT 4 条字幕时间戳连续：每段 start = 上段 end，不再出现 200ms 缝隙。

## 验证

输入 `coffee. coffee. coffee. I drink coffee every morning.` 连续生成 3 次，SRT 均为 4 段且时间戳连续，wav 段间无静音。
