### PR TITLE
[ISSUE-24] 新增 CLAUDE.md/AGENTS.md，记录服务启动坑

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# IndexTTS2 项目说明
+
+本仓库维护一个 FastAPI TTS 服务（`http_service.py`），通过 HTTP 提供文本转语音 + SRT 字幕。详细使用参考 `docs/http_service.md`。
+
+## 启动 HTTP 服务
+
+只用 `.venv/bin/python http_service.py` 启动，**不要用 `uv run`**。
+原因：`uv run` 每次都做依赖解析，当前 `deepspeed` extra 与 `descript-audiotools` 在 protobuf/grpcio-health-checking 版本上冲突，会空转几十秒后失败。`.venv` 里的依赖已可直接跑。


### PR DESCRIPTION
close #24

## 改动

- 新增 `CLAUDE.md`：极简介绍——仓库维护 FastAPI TTS 服务（详情见 `docs/http_service.md`），启动必须 `.venv/bin/python http_service.py`，禁用 `uv run`，并附上原因（deepspeed extra 与 descript-audiotools 在 protobuf/grpcio-health-checking 上冲突）。
- 新增 `AGENTS.md`：软链 `CLAUDE.md`，满足 "一实一链" 约束。

仅原则与坑，避免堆细节文档。
