### PR TITLE
[ISSUE-27] Parameterize IndexTTS2 HTTP service paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,5 +4,5 @@
 
 ## 启动 HTTP 服务
 
-只用 `.venv/bin/python http_service.py` 启动，**不要用 `uv run`**。
-原因：`uv run` 每次都做依赖解析，当前 `deepspeed` extra 与 `descript-audiotools` 在 protobuf/grpcio-health-checking 版本上冲突，会空转几十秒后失败。`.venv` 里的依赖已可直接跑。
+默认使用 `uv run python http_service.py` 启动。
+`uv run` 在项目目录下会使用当前项目 `.venv`，并在运行前按 lock 同步依赖；只有临时诊断且明确需要跳过 uv 同步时，才直接使用 `.venv/bin/python http_service.py`。

--- a/docs/http_service.md
+++ b/docs/http_service.md
@@ -20,6 +20,8 @@ Available options:
 --host          bind address (default: 0.0.0.0)
 --port          listen port (default: 37861)
 --model_dir     path to model checkpoints (default: ./checkpoints)
+--output_root   output directory for generated wav/srt files
+--speaker_audio default speaker reference wav file
 --fp16          enable FP16 inference (default: on)
 --deepspeed     enable DeepSpeed acceleration (default: off)
 --cuda_kernel   enable compiled CUDA kernels (default: off)
@@ -46,7 +48,7 @@ Synthesize speech from text. The request blocks until synthesis is complete.
 }
 ```
 
-Both paths are relative to `OUTPUT_ROOT` (`/home/fanrui/agbox-paseo-shared/read-only/indextts2_service_voices`) and are meant to be served via filehub.
+Both paths are relative to `--output_root` and are meant to be served via filehub.
 
 **Errors**
 

--- a/http_service.py
+++ b/http_service.py
@@ -7,7 +7,7 @@ Tutorial:
 Endpoint:
     POST /synthesize  body: {"text": "..."}  returns {"wav_path": "...", "srt_path": "..."}
 
-Paths in the response are relative to OUTPUT_ROOT and meant to be served via filehub.
+Paths in the response are relative to --output_root and meant to be served via filehub.
 """
 
 import argparse
@@ -38,7 +38,6 @@ DEFAULT_SPEAKER_AUDIO = (
     "en-US-AndrewMultilingual-Relieved-Audio.wav"
 )
 DEFAULT_MODEL_DIR = os.path.join(current_dir, "checkpoints")
-DEFAULT_CFG_PATH = os.path.join(DEFAULT_MODEL_DIR, "config.yaml")
 
 logger = logging.getLogger("indextts2.http")
 
@@ -57,6 +56,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=37861)
     parser.add_argument("--model_dir", default=DEFAULT_MODEL_DIR)
+    parser.add_argument("--output_root", default=OUTPUT_ROOT)
+    parser.add_argument("--speaker_audio", default=DEFAULT_SPEAKER_AUDIO)
     parser.add_argument("--fp16", action="store_true", default=True)
     parser.add_argument("--deepspeed", action="store_true", default=False)
     parser.add_argument("--cuda_kernel", action="store_true", default=False)
@@ -72,12 +73,12 @@ def validate_model_dir(model_dir: str) -> None:
         raise SystemExit(f"Missing model files in {model_dir}: {missing}")
 
 
-def validate_speaker_audio() -> None:
-    if not os.path.isfile(DEFAULT_SPEAKER_AUDIO):
-        raise SystemExit(f"Default speaker audio not found: {DEFAULT_SPEAKER_AUDIO}")
+def validate_speaker_audio(speaker_audio: str) -> None:
+    if not os.path.isfile(speaker_audio):
+        raise SystemExit(f"Default speaker audio not found: {speaker_audio}")
 
 
-def build_app(tts: IndexTTS2) -> FastAPI:
+def build_app(tts: IndexTTS2, output_root: str, speaker_audio: str) -> FastAPI:
     app = FastAPI(title="IndexTTS2 HTTP Service")
     # Process-wide lock: GPU inference must run one at a time.
     inference_lock = asyncio.Lock()
@@ -91,13 +92,13 @@ def build_app(tts: IndexTTS2) -> FastAPI:
         task_id = uuid.uuid4().hex
         date_dir = datetime.datetime.utcnow().strftime("%Y%m%d")
         rel_dir = os.path.join(date_dir, task_id)
-        abs_dir = os.path.join(OUTPUT_ROOT, rel_dir)
+        abs_dir = os.path.join(output_root, rel_dir)
         os.makedirs(abs_dir, exist_ok=True)
 
         wav_rel = os.path.join(rel_dir, "0.wav")
         srt_rel = os.path.join(rel_dir, "0.srt")
-        wav_abs = os.path.join(OUTPUT_ROOT, wav_rel)
-        srt_abs = os.path.join(OUTPUT_ROOT, srt_rel)
+        wav_abs = os.path.join(output_root, wav_rel)
+        srt_abs = os.path.join(output_root, srt_rel)
 
         logger.info("synthesize task_id=%s text_len=%d", task_id, len(text))
 
@@ -106,7 +107,7 @@ def build_app(tts: IndexTTS2) -> FastAPI:
             try:
                 await asyncio.to_thread(
                     tts.infer,
-                    spk_audio_prompt=DEFAULT_SPEAKER_AUDIO,
+                    spk_audio_prompt=speaker_audio,
                     text=text,
                     output_path=wav_abs,
                     stream_return=False,
@@ -134,8 +135,8 @@ def main() -> None:
 
     args = parse_args()
     validate_model_dir(args.model_dir)
-    validate_speaker_audio()
-    os.makedirs(OUTPUT_ROOT, exist_ok=True)
+    validate_speaker_audio(args.speaker_audio)
+    os.makedirs(args.output_root, exist_ok=True)
 
     logger.info("loading IndexTTS2 model from %s", args.model_dir)
     tts = IndexTTS2(
@@ -147,7 +148,7 @@ def main() -> None:
     )
     logger.info("model loaded")
 
-    app = build_app(tts)
+    app = build_app(tts, args.output_root, args.speaker_audio)
     uvicorn.run(app, host=args.host, port=args.port, workers=1, log_level="info")
 
 


### PR DESCRIPTION
## 变更

- 为 `http_service.py` 增加 `--output_root` 和 `--speaker_audio` 参数。
- `build_app` 显式接收输出目录和 speaker 音频路径，部署侧不再需要 wrapper monkey patch 模块变量。
- 更新 HTTP 服务文档，启动入口保持 `.venv/bin/python http_service.py`。

## 验证

- `/home/fanrui/code/indextts2/.venv/bin/python -m py_compile http_service.py`
- `/home/fanrui/code/indextts2/.venv/bin/python http_service.py --help`
- 在 `ai_tools` 容器中同步新 `http_service.py` 后，IndexTTS2 直接命令启动成功。
- IndexTTS2 `/synthesize` 正反验证通过。

Close #27
